### PR TITLE
Solucion de error Pantalla de muestra_calf_psicologica debe regresar a sel_candidato_co…

### DIFF
--- a/templates/mue_cal_psicologica.html
+++ b/templates/mue_cal_psicologica.html
@@ -149,7 +149,7 @@
     </div>
     <br>
     &nbsp;&nbsp;&nbsp;
-    <a class="btn btn-primary" href="/agr_candidato_contratacion" style="background:lightseagreen">Regresar</a>
+    <a class="btn btn-primary" href="/sel_candidato_contratacion/{{sol.0}}" style="background:lightseagreen">Regresar</a>
 
     </body>
 </form>


### PR DESCRIPTION
…ntratacion

En el menú de contratación, y seleccion, en sel_candidato_contratacion al presionar el botón ver P.S y mostrar la página, el botón regresar debe llevar a la página sel_candidato_contratacion